### PR TITLE
Add debugging script to assist issue triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,20 @@ To rotate your HyperPixel4 you must edit /boot/config.txt and change the followi
 This will rotate both the display and the touchscreen input to match.
 
 If you're using a non-touchscreen HyperPixel4 you need only change `display_rotate`.
+
+## Troubleshooting
+
+Where possible we are collecting known FAQs under the `notice` label in our issue tracker.
+
+[`Notice` Issue Tracker](https://github.com/pimoroni/hyperpixel4/issues?q=is%3Aissue+label%3Anotice+)
+
+If your issue is not covered by one of these provided by our team and community 
+then we ask you to provide some debugging information using the following oneliner:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/pimoroni/hyperpixel4/master/hyperpixel4-debug.sh | bash
+```
+
+Then [file a bug report](https://github.com/pimoroni/hyperpixel4/issues/new/choose).
+
+

--- a/hyperpixel4-debug.sh
+++ b/hyperpixel4-debug.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+function title(){
+  echo ""
+  echo "## $1"
+  echo ""
+}
+
+title "Platform Information"
+cat /proc/cpuinfo | grep Revision
+lsb_release --description
+uname -r
+
+title "Touchscreen logs"
+echo "Rectangular: Goodix"
+dmesg | grep Goodix
+echo "Square: ft5"
+dmesg | grep ft5
+
+title "I2C Devices and Mappings"
+for x in "$(ls /dev/i2c-*)"
+do
+  echo "$x"
+  i2cdetect -y "${x:9:1}"
+done
+
+title "Boot Config"
+cat /boot/config.txt


### PR DESCRIPTION
# Summary 

Just a suggestion to help collecting information for issue triage that can be put front and centre on the readme on:
1. how to get others to self-serve sorting out their own issues 
2. Easily collect the information needed for triage
3. You can update the triage oneliner over time too.

## Example Oneliner from my repo

Until this gets merged you can test the script using:

```bash
curl -sSL https://raw.githubusercontent.com/neozenith/hyperpixel4/master/hyperpixel4-debug.sh | bash
```

or the following if the preferred option is to output to file rather than terminal.

```bash
curl -sSL https://raw.githubusercontent.com/neozenith/hyperpixel4/master/hyperpixel4-debug.sh | bash &> debugging.log
```
## Sample Output 

```

## Platform Information

Revision	: c03111
Description:	Raspbian GNU/Linux 10 (buster)
4.19.97-v7l+


## Touchscreen logs

Rectangular: Goodix
[    4.238758] Goodix-TS 7-0014: ID 911, version: 1060
[    4.289760] input: Goodix Capacitive TouchScreen as /devices/platform/i2c@0/i2c-7/7-0014/input/input0
Square: ft5


## I2C Devices and Mappings

/dev/i2c-7
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:          -- -- -- -- -- -- -- -- -- -- -- -- -- 
10: -- -- -- -- UU -- -- -- -- -- -- -- -- -- -- -- 
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
70: -- -- -- -- -- -- -- --                         


## Boot Config

# For more options and information see
# http://rpf.io/configtxt
# Some settings may impact device functionality. See link above for details

# uncomment if you get no picture on HDMI for a default "safe" mode
#hdmi_safe=1

# uncomment this if your display has a black border of unused pixels visible
# and your display can output without overscan
#disable_overscan=1

# uncomment the following to adjust overscan. Use positive numbers if console
# goes off screen, and negative if there is too much border
#overscan_left=16
#overscan_right=16
#overscan_top=16
#overscan_bottom=16

# uncomment to force a console size. By default it will be display's size minus
# overscan.
framebuffer_width=720
framebuffer_height=480

# uncomment if hdmi display is not detected and composite is being output
hdmi_force_hotplug=1

# uncomment to force a specific HDMI mode (this will force VGA)
#hdmi_group=1
#hdmi_mode=1

# uncomment to force a HDMI mode rather than DVI. This can make audio work in
# DMT (computer monitor) modes
#hdmi_drive=2

# uncomment to increase signal to HDMI, if you have interference, blanking, or
# no display
#config_hdmi_boost=4

# uncomment for composite PAL
#sdtv_mode=2

#uncomment to overclock the arm. 700 MHz is the default.
#arm_freq=800

# Uncomment some or all of these to enable the optional hardware interfaces
#dtparam=i2c_arm=on
#dtparam=i2s=on
#dtparam=spi=on

# Uncomment this to enable the lirc-rpi module
#dtoverlay=lirc-rpi

# Additional overlays and parameters are documented /boot/overlays/README

# Enable audio (loads snd_bcm2835)
dtparam=audio=on

[pi4]
# Enable DRM VC4 V3D driver on top of the dispmanx display stack
dtoverlay=vc4-fkms-v3d
max_framebuffers=2

[all]
#dtoverlay=vc4-fkms-v3d

# NOOBS Auto-generated Settings:
hdmi_force_hotplug=1
start_x=1
gpu_mem=128

# RaspberryPi Docs on DPI
# https://www.raspberrypi.org/documentation/hardware/raspberrypi/dpi/
dtoverlay=hyperpixel4
gpio=0-25=a2
enable_dpi_lcd=1

dpi_group=2
dpi_mode=87
dpi_output_format=0x7f216
dpi_timings=480 0 10 16 59 800 0 15 113 15 0 0 0 60 0 32000000 6
```
